### PR TITLE
Fix #18: last item in the menu is offscreen when the menu is full

### DIFF
--- a/eoa.ee/main.html
+++ b/eoa.ee/main.html
@@ -19,7 +19,7 @@
     }
 
     .sidenav {
-        height: 100%; /* 100% Full-height */
+        bottom: 0px; /* Stay at the bottom */
         width: 0; /* 0 width - change this with JavaScript */
         position: fixed; /* Stay in place */
         z-index: 1; /* Stay on top */


### PR DESCRIPTION
#18

Use `bottom: 0px;` instead of `height: 100%;` since the content is offset by padding.