### PR TITLE
Move credentials out of index.php

### DIFF
--- a/eoa.ee/.gitignore
+++ b/eoa.ee/.gitignore
@@ -1,0 +1,1 @@
+credentials.php

--- a/eoa.ee/index.php
+++ b/eoa.ee/index.php
@@ -78,10 +78,7 @@
 
 <?php
 
-$servername = "localhost";
-$username = "";
-$password = "";
-$dbname = "eoa";
+include 'credentials.php';
 
 $conn = new mysqli($servername, $username, $password, $dbname);
 


### PR DESCRIPTION
Resolves #26

Currently, the credentials are in the same format in `credentials.php` inside a PHP tag, but this could be moved outside the webroot in the future.